### PR TITLE
Fix method reference in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const key = Uint8Array.from([
 const plaintext = "Hello world";
 const ciphertext = await aes.encrypt(key, message);
 const plaintext = await aes.decrypt(key, ciphertext);
-console.log(aes.toUTF8(plaintext) === message);
+console.log(aes.utils.bytesToUtf8(plaintext) === message);
 // Also works in browsers
 ```
 


### PR DESCRIPTION
Assuming `aes.toUTF8()` was refactored at some point to `aes.utils.bytesToUtf8()`. This updates the example accordingly.